### PR TITLE
Add dotenv as requiremented

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 openai
 gradio
+dotenv


### PR DESCRIPTION
To suppress error message: `ModuleNotFoundError: No module named 'dotenv'`